### PR TITLE
Enable reward history and era points charts by replacing the Subscan API with the Stats App API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - The `useSubscan` hook has been replaced with the `useCereStats` hook for the Reward History and Era Point Charts data source.
+
+## Removed
 - Removed dependency on `Subscan API` and simplified data management strategy by using `CereStats` API as primary data source.
 
 ## [1.0.1] - 2023-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [vNext] - Date
 
 ## Added
+
 - Added `CereStatsProvider` feature to fetch data from CereStats API, providing reward history and era points for validators.
 - Implemented custom hooks, `useFetchEraPoints` and `usePayouts`, to manage data from CereStats API. `useFetchEraPoints` retrieves era points for a specific validator, while `usePayouts` manages reward history.
 
 ## Changed
+
 - The `useSubscan` hook has been replaced with the `useCereStats` hook for the Reward History and Era Point Charts data source.
 
 ## Removed
+
 - Removed dependency on `Subscan API` and simplified data management strategy by using `CereStats` API as primary data source.
 
 ## [1.0.1] - 2023-05-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [vNext] - Date
+
+## Added
+- Added `CereStatsProvider` feature to fetch data from CereStats API, providing reward history and era points for validators.
+- Implemented custom hooks, `useFetchEraPoints` and `usePayouts`, to manage data from CereStats API. `useFetchEraPoints` retrieves era points for a specific validator, while `usePayouts` manages reward history.
+
+## Changed
+- The `useSubscan` hook has been replaced with the `useCereStats` hook for the Reward History and Era Point Charts data source.
+- Removed dependency on `Subscan API` and simplified data management strategy by using `CereStats` API as primary data source.
+
 ## [1.0.1] - 2023-05-18
 
 ## Added

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "apache-2.0",
   "private": false,
   "dependencies": {
+    "@apollo/client": "^3.7.14",
     "@fortawesome/fontawesome-svg-core": "6.1.0",
     "@fortawesome/free-brands-svg-icons": "^6.1.1",
     "@fortawesome/free-regular-svg-icons": "^5.15.4",
@@ -31,6 +32,7 @@
     "downshift": "^6.1.7",
     "follow-redirects": ">=1.14.8",
     "framer-motion": "^6.2.4",
+    "graphql": "^16.6.0",
     "lodash.throttle": "^4.1.1",
     "moment": "^2.29.4",
     "nth-check": ">=2.0.1",
@@ -46,6 +48,7 @@
     "react-scroll": "^1.8.6",
     "styled-components": "^5.3.3",
     "styled-theming": "^2.2.0",
+    "subscriptions-transport-ws": "^0.11.0",
     "typescript": "^4.5.5",
     "web-vitals": "^2.1.4",
     "window-or-global": "^1.0.1",

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -23,12 +23,11 @@ import { PoolMembershipsProvider } from './contexts/Pools/PoolMemberships';
 import { ActivePoolProvider } from './contexts/Pools/ActivePool';
 import { SideBarProvider } from './contexts/SideBar';
 import { StakingProvider } from './contexts/Staking';
-import { SubscanProvider } from './contexts/Subscan';
+import { CereStatsProvider } from './contexts/CereStats';
 import { ValidatorsProvider } from './contexts/Validators';
 import { UIProvider } from './contexts/UI';
 import { useTheme } from './contexts/Themes';
 import { SessionEraProvider } from './contexts/SessionEra';
-import { CereStatsProvider } from './contexts/CereStats';
 
 export const WrappedRouter = () => (
   <Wrapper>
@@ -64,7 +63,6 @@ export const Providers = withProviders(
   ValidatorsProvider,
   UIProvider,
   CereStatsProvider,
-  SubscanProvider,
   MenuProvider,
   TooltipProvider,
   PaletteProvider,

--- a/src/Providers.tsx
+++ b/src/Providers.tsx
@@ -28,6 +28,7 @@ import { ValidatorsProvider } from './contexts/Validators';
 import { UIProvider } from './contexts/UI';
 import { useTheme } from './contexts/Themes';
 import { SessionEraProvider } from './contexts/SessionEra';
+import { CereStatsProvider } from './contexts/CereStats';
 
 export const WrappedRouter = () => (
   <Wrapper>
@@ -62,6 +63,7 @@ export const Providers = withProviders(
   ActivePoolProvider,
   ValidatorsProvider,
   UIProvider,
+  CereStatsProvider,
   SubscanProvider,
   MenuProvider,
   TooltipProvider,

--- a/src/config/networks.ts
+++ b/src/config/networks.ts
@@ -22,6 +22,7 @@ const cereMainnet = {
   },
   endpoint: 'wss://archive.mainnet.cere.network/ws',
   subscanEndpoint: '',
+  cereStatsEndpoint: 'wss://hasura.stats.cere.network/v1/graphql',
   unit: 'CERE',
   units: 10,
   ss58: 54,
@@ -51,6 +52,7 @@ const cereTestnet = {
   ...cereMainnet,
   name: 'Cere Testnet',
   endpoint: 'wss://archive.testnet.cere.network/ws',
+  cereStatsEndpoint: 'wss://hasura.stats.dev.cere.network/v1/graphql',
 };
 
 // Determine if the testnet should be included based on the REACT_APP_INCLUDE_TESTNET environment variable

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -71,8 +71,7 @@ export const MEDIUM_FONT_SiZE_MAX_WIDTH = 1600;
 /*
  * Toggle-able services
  */
-// TODO: Add 'cereStats' in the future.
-export const SERVICES = ['subscan'];
+export const SERVICES = ['cereStats'];
 
 /*
  * Fallback config values

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -71,7 +71,8 @@ export const MEDIUM_FONT_SiZE_MAX_WIDTH = 1600;
 /*
  * Toggle-able services
  */
-export const SERVICES = [];
+// TODO: Add 'cereStats' in the future.
+export const SERVICES = ['subscan'];
 
 /*
  * Fallback config values

--- a/src/contexts/CereStats/defaults.ts
+++ b/src/contexts/CereStats/defaults.ts
@@ -1,0 +1,6 @@
+import { CereStatsContextInterface } from './types';
+
+export const defaultCereStatsContext: CereStatsContextInterface = {
+  fetchEraPoints: (v, e) => {},
+  payouts: [],
+};

--- a/src/contexts/CereStats/defaults.ts
+++ b/src/contexts/CereStats/defaults.ts
@@ -3,4 +3,5 @@ import { CereStatsContextInterface } from './types';
 export const defaultCereStatsContext: CereStatsContextInterface = {
   fetchEraPoints: (v, e) => {},
   payouts: [],
+  poolClaims: [],
 };

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -86,6 +86,27 @@ export const CereStatsProvider = ({
     return data.era_points;
   };
 
+  const normalizePayouts = (
+    payoutData: { block_number: number; data: string; timestamp: number }[]
+  ) => {
+    return payoutData.map(({ block_number, data, timestamp }) => {
+      let amount = 0;
+
+      // Using regex to extract the second parameter from the data string
+      const match = data.match(/,\s*(\d+)\s*\]/);
+
+      if (match && match[1]) {
+        amount = parseInt(match[1], 10);
+      }
+
+      return {
+        amount,
+        block_num: block_number,
+        block_timestamp: timestamp * 1000,
+      };
+    });
+  };
+
   const fetchPayouts = async () => {
     if (!activeAccount || !client) {
       return;
@@ -112,7 +133,8 @@ export const CereStatsProvider = ({
       },
     });
 
-    setPayouts(data.payouts); // replace with the actual key in the response
+    // @ts-ignore
+    setPayouts(normalizePayouts(data.event));
   };
 
   if (!client) {

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -98,7 +98,7 @@ export const CereStatsProvider = ({
             where: {
               section: { _eq: "staking" }
               method: { _like: "Reward%" }
-              data: { _regex: $activeAccount }
+              data: { _like: $activeAccount }
             }
           ) {
             block_number
@@ -108,7 +108,7 @@ export const CereStatsProvider = ({
         }
       `,
       variables: {
-        activeAccount,
+        activeAccount: `%${activeAccount}%`,
       },
     });
 

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -93,13 +93,12 @@ export const CereStatsProvider = ({
 
     const { data } = await client.query({
       query: gql`
-        query Event($accountId: String!) {
+        query RewardEvents($activeAccount: String) {
           event(
-            order_by: { block_number: desc }
             where: {
               section: { _eq: "staking" }
               method: { _like: "Reward%" }
-              data: { _like: $accountId }
+              data: { _regex: $activeAccount }
             }
           ) {
             block_number
@@ -108,7 +107,9 @@ export const CereStatsProvider = ({
           }
         }
       `,
-      variables: { accountId: activeAccount },
+      variables: {
+        activeAccount,
+      },
     });
 
     setPayouts(data.payouts); // replace with the actual key in the response

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -83,7 +83,11 @@ export const CereStatsProvider = ({
       variables: { stashAddress: address },
     });
 
-    return data.era_points;
+    // eslint-disable-next-line @typescript-eslint/no-shadow
+    return data.era_points.map(({ era, points }: any) => ({
+      era,
+      reward_point: points,
+    }));
   };
 
   const normalizePayouts = (

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -3,11 +3,15 @@ import {
   ApolloClient,
   NormalizedCacheObject,
   InMemoryCache,
+  gql,
 } from '@apollo/client';
 import { WebSocketLink } from '@apollo/client/link/ws';
 import { defaultCereStatsContext } from './defaults';
 import { CereStatsContextInterface } from './types';
 import { useConnect } from '../Connect';
+import { useApi } from '../Api';
+import { UIContextInterface } from '../UI/types';
+import { useUi } from '../UI';
 
 const CereStatsContext = createContext<CereStatsContextInterface>(
   defaultCereStatsContext
@@ -20,32 +24,30 @@ export const CereStatsProvider = ({
 }: {
   children: React.ReactNode;
 }) => {
+  const { network, isReady } = useApi();
+  const { services }: UIContextInterface = useUi();
   const { activeAccount } = useConnect();
-  console.log('activeAccount', activeAccount);
 
   const [client, setClient] =
     useState<ApolloClient<NormalizedCacheObject> | null>(null);
   const [payouts, setPayouts] = useState([]);
 
-  // replace with your era points GraphQL query
-  const ERA_POINTS_QUERY = `
-      subscription EraPoints($stashAddress: String) {
-        era_points(
-          where: { stash_address: { _eq: $stashAddress } }
-        ) {
-          stash_address
-          era
-          points
-        }
-      }
-    `;
+  // reset payouts on network switch
+  useEffect(() => {
+    setPayouts([]);
+  }, [network]);
 
-  // replace with your payouts GraphQL query
-  const PAYOUTS_QUERY = `
-    query FetchPayouts {
-      //...
+  // fetch payouts as soon as network is ready
+  useEffect(() => {
+    if (isReady) {
+      fetchPayouts();
     }
-  `;
+  }, [isReady, network, activeAccount]);
+
+  // fetch payouts on services toggle
+  useEffect(() => {
+    fetchPayouts();
+  }, [services]);
 
   useEffect(() => {
     const wsLink = new WebSocketLink({
@@ -68,6 +70,19 @@ export const CereStatsProvider = ({
       return [];
     }
 
+    // replace with your era points GraphQL query
+    const ERA_POINTS_QUERY = `
+      subscription EraPoints($stashAddress: String) {
+        era_points(
+          where: { stash_address: { _eq: $stashAddress } }
+        ) {
+          stash_address
+          era
+          points
+        }
+      }
+    `;
+
     const { data } = await client.query({
       // @ts-ignore
       query: ERA_POINTS_QUERY,
@@ -77,15 +92,29 @@ export const CereStatsProvider = ({
     return data.eraPoints; // replace with the actual key in the response
   };
 
-  const fetchPayouts = async (address: string) => {
-    if (!address || !client) {
+  const fetchPayouts = async () => {
+    if (!activeAccount || !client) {
       return;
     }
 
     const { data } = await client.query({
-      // @ts-ignore
-      query: PAYOUTS_QUERY,
-      variables: { address },
+      query: gql`
+        query Event($accountId: String!) {
+          event(
+            order_by: { block_number: desc }
+            where: {
+              section: { _eq: "staking" }
+              method: { _like: "Reward%" }
+              data: { _like: $accountId }
+            }
+          ) {
+            block_number
+            data
+            timestamp
+          }
+        }
+      `,
+      variables: { accountId: activeAccount },
     });
 
     setPayouts(data.payouts); // replace with the actual key in the response

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -74,7 +74,6 @@ export const CereStatsProvider = ({
       query: gql`
         query EraPoints($stashAddress: String) {
           era_points(where: { stash_address: { _eq: $stashAddress } }) {
-            stash_address
             era
             points
           }

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -35,7 +35,9 @@ const useApolloClient = (endpoint: Network['cereStatsEndpoint']) => {
   return client;
 };
 
-const useEraPoints = (client: ApolloClient<NormalizedCacheObject> | null) => {
+const useFetchEraPoints = (
+  client: ApolloClient<NormalizedCacheObject> | null
+) => {
   const fetchEraPoints = async (address: string) => {
     if (!address || !client) {
       return [];
@@ -144,7 +146,7 @@ export const CereStatsProvider = ({
   const { activeAccount } = useConnect();
 
   const client = useApolloClient(network.cereStatsEndpoint);
-  const fetchEraPoints = useEraPoints(client);
+  const fetchEraPoints = useFetchEraPoints(client);
   const payouts = usePayouts(client, activeAccount);
 
   if (!client) {

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -70,26 +70,20 @@ export const CereStatsProvider = ({
       return [];
     }
 
-    // replace with your era points GraphQL query
-    const ERA_POINTS_QUERY = `
-      subscription EraPoints($stashAddress: String) {
-        era_points(
-          where: { stash_address: { _eq: $stashAddress } }
-        ) {
-          stash_address
-          era
-          points
-        }
-      }
-    `;
-
     const { data } = await client.query({
-      // @ts-ignore
-      query: ERA_POINTS_QUERY,
-      variables: { address, era },
+      query: gql`
+        query EraPoints($stashAddress: String) {
+          era_points(where: { stash_address: { _eq: $stashAddress } }) {
+            stash_address
+            era
+            points
+          }
+        }
+      `,
+      variables: { stashAddress: address },
     });
 
-    return data.eraPoints; // replace with the actual key in the response
+    return data.era_points;
   };
 
   const fetchPayouts = async () => {

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -38,7 +38,7 @@ const useApolloClient = (endpoint: Network['cereStatsEndpoint']) => {
 const useFetchEraPoints = (
   client: ApolloClient<NormalizedCacheObject> | null
 ) => {
-  const fetchEraPoints = async (address: string) => {
+  const fetchEraPoints = async (address: string, activeEraIndex: number) => {
     if (!address || !client) {
       return [];
     }
@@ -55,10 +55,20 @@ const useFetchEraPoints = (
       variables: { stashAddress: address },
     });
 
-    return data.era_points.map(({ era, points }: any) => ({
-      era,
-      reward_point: points,
-    }));
+    if (data?.era_points !== null) {
+      const list = [];
+      for (let i = activeEraIndex; i > activeEraIndex - 100; i--) {
+        list.push({
+          era: i,
+          reward_point:
+            data.era_points.find((item: any) => item.era === i)?.points ?? 0,
+        });
+      }
+      // removes last zero item and returns
+      return list.reverse().splice(0, list.length - 1);
+    }
+
+    return [];
   };
 
   return fetchEraPoints;

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -151,6 +151,7 @@ export const CereStatsProvider = ({
       value={{
         fetchEraPoints,
         payouts,
+        poolClaims: [],
       }}
     >
       {children}

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -1,0 +1,108 @@
+import React, { useState, useEffect, createContext } from 'react';
+import {
+  ApolloClient,
+  NormalizedCacheObject,
+  InMemoryCache,
+} from '@apollo/client';
+import { WebSocketLink } from '@apollo/client/link/ws';
+import { defaultCereStatsContext } from './defaults';
+import { CereStatsContextInterface } from './types';
+import { useConnect } from '../Connect';
+
+const CereStatsContext = createContext<CereStatsContextInterface>(
+  defaultCereStatsContext
+);
+
+export const useCereStats = () => React.useContext(CereStatsContext);
+
+export const CereStatsProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const { activeAccount } = useConnect();
+  console.log('activeAccount', activeAccount);
+
+  const [client, setClient] =
+    useState<ApolloClient<NormalizedCacheObject> | null>(null);
+  const [payouts, setPayouts] = useState([]);
+
+  // replace with your era points GraphQL query
+  const ERA_POINTS_QUERY = `
+      subscription EraPoints($stashAddress: String) {
+        era_points(
+          where: { stash_address: { _eq: $stashAddress } }
+        ) {
+          stash_address
+          era
+          points
+        }
+      }
+    `;
+
+  // replace with your payouts GraphQL query
+  const PAYOUTS_QUERY = `
+    query FetchPayouts {
+      //...
+    }
+  `;
+
+  useEffect(() => {
+    const wsLink = new WebSocketLink({
+      uri: 'wss://hasura.stats.cere.network/v1/graphql',
+      options: {
+        reconnect: true,
+      },
+    });
+
+    const _client = new ApolloClient({
+      link: wsLink,
+      cache: new InMemoryCache(),
+    });
+
+    setClient(_client);
+  }, []);
+
+  const fetchEraPoints = async (address: string, era: number) => {
+    if (!address || !client) {
+      return [];
+    }
+
+    const { data } = await client.query({
+      // @ts-ignore
+      query: ERA_POINTS_QUERY,
+      variables: { address, era },
+    });
+
+    return data.eraPoints; // replace with the actual key in the response
+  };
+
+  const fetchPayouts = async (address: string) => {
+    if (!address || !client) {
+      return;
+    }
+
+    const { data } = await client.query({
+      // @ts-ignore
+      query: PAYOUTS_QUERY,
+      variables: { address },
+    });
+
+    setPayouts(data.payouts); // replace with the actual key in the response
+  };
+
+  if (!client) {
+    return null;
+  }
+
+  return (
+    <CereStatsContext.Provider
+      value={{
+        fetchEraPoints,
+        payouts,
+      }}
+    >
+      {children}
+    </CereStatsContext.Provider>
+  );
+};

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -89,22 +89,24 @@ export const CereStatsProvider = ({
   const normalizePayouts = (
     payoutData: { block_number: number; data: string; timestamp: number }[]
   ) => {
-    return payoutData.map(({ block_number, data, timestamp }) => {
-      let amount = 0;
+    return payoutData
+      .map(({ block_number, data, timestamp }) => {
+        let amount = 0;
 
-      // Using regex to extract the second parameter from the data string
-      const match = data.match(/,\s*(\d+)\s*\]/);
+        // Using regex to extract the second parameter from the data string
+        const match = data.match(/,\s*(\d+)\s*\]/);
 
-      if (match && match[1]) {
-        amount = parseInt(match[1], 10);
-      }
+        if (match && match[1]) {
+          amount = parseInt(match[1], 10);
+        }
 
-      return {
-        amount,
-        block_num: block_number,
-        block_timestamp: timestamp * 1000,
-      };
-    });
+        return {
+          amount,
+          block_num: block_number,
+          block_timestamp: timestamp,
+        };
+      })
+      .sort((a, b) => b.block_timestamp - a.block_timestamp);
   };
 
   const fetchPayouts = async () => {

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -51,7 +51,7 @@ export const CereStatsProvider = ({
 
   useEffect(() => {
     const wsLink = new WebSocketLink({
-      uri: 'wss://hasura.stats.cere.network/v1/graphql',
+      uri: network.cereStatsEndpoint,
       options: {
         reconnect: true,
       },
@@ -63,7 +63,7 @@ export const CereStatsProvider = ({
     });
 
     setClient(_client);
-  }, []);
+  }, [network]);
 
   const fetchEraPoints = async (address: string, era: number) => {
     if (!address || !client) {

--- a/src/contexts/CereStats/index.tsx
+++ b/src/contexts/CereStats/index.tsx
@@ -57,7 +57,10 @@ const useFetchEraPoints = (
 
     if (data?.era_points !== null) {
       const list = [];
-      for (let i = activeEraIndex; i > activeEraIndex - 100; i--) {
+      // Set a constant for the number of eras we want to display
+      const ERAS_TO_SHOW = 100;
+
+      for (let i = activeEraIndex; i > activeEraIndex - ERAS_TO_SHOW; i--) {
         list.push({
           era: i,
           reward_point:

--- a/src/contexts/CereStats/types.ts
+++ b/src/contexts/CereStats/types.ts
@@ -1,0 +1,4 @@
+export interface CereStatsContextInterface {
+  fetchEraPoints: (v: string, e: number) => void;
+  payouts: any;
+}

--- a/src/contexts/CereStats/types.ts
+++ b/src/contexts/CereStats/types.ts
@@ -1,4 +1,7 @@
 export interface CereStatsContextInterface {
   fetchEraPoints: (v: string, e: number) => void;
   payouts: any;
+  // The Cere Stats API does not currently support `poolClaims`.
+  // We need it to maintain consistency with the `useSubscan` hook and for possible future support of `poolClaims`.
+  poolClaims: [];
 }

--- a/src/contexts/CereStats/types.ts
+++ b/src/contexts/CereStats/types.ts
@@ -1,7 +1,7 @@
 export interface CereStatsContextInterface {
   fetchEraPoints: (v: string, e: number) => void;
   payouts: any;
-  // The Cere Stats API does not currently support `poolClaims`.
+  // The Cere Stats does not currently support `poolClaims`.
   // We need it to maintain consistency with the `useSubscan` hook and for possible future support of `poolClaims`.
   poolClaims: [];
 }

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -50,7 +50,7 @@ export const PayoutBar = (props: PayoutBarProps) => {
   const { isSyncing } = useUi();
   const { inSetup } = useStaking();
   const { membership } = usePoolMemberships();
-  const { payouts } = useCereStats();
+  const { payouts, poolClaims } = useCereStats();
 
   const { units } = network;
   const notStaking = !isSyncing && inSetup() && !membership;
@@ -59,7 +59,7 @@ export const PayoutBar = (props: PayoutBarProps) => {
     days,
     units,
     payouts,
-    []
+    poolClaims
   );
 
   // determine color for payouts

--- a/src/library/Graphs/PayoutBar.tsx
+++ b/src/library/Graphs/PayoutBar.tsx
@@ -27,7 +27,7 @@ import { useUi } from 'contexts/UI';
 import { useStaking } from 'contexts/Staking';
 import { AnySubscan } from 'types';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
-import { useSubscan } from 'contexts/Subscan';
+import { useCereStats } from 'contexts/CereStats';
 import { PayoutBarProps } from './types';
 import { formatRewardsForGraphs } from './Utils';
 
@@ -50,7 +50,7 @@ export const PayoutBar = (props: PayoutBarProps) => {
   const { isSyncing } = useUi();
   const { inSetup } = useStaking();
   const { membership } = usePoolMemberships();
-  const { payouts, poolClaims } = useSubscan();
+  const { payouts } = useCereStats();
 
   const { units } = network;
   const notStaking = !isSyncing && inSetup() && !membership;
@@ -59,7 +59,7 @@ export const PayoutBar = (props: PayoutBarProps) => {
     days,
     units,
     payouts,
-    poolClaims
+    []
   );
 
   // determine color for payouts

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -25,7 +25,7 @@ import { useUi } from 'contexts/UI';
 import { useStaking } from 'contexts/Staking';
 import { usePoolMemberships } from 'contexts/Pools/PoolMemberships';
 import { AnySubscan } from 'types';
-import { useSubscan } from 'contexts/Subscan';
+import { useCereStats } from 'contexts/CereStats';
 import { PayoutLineProps } from './types';
 import { combineRewardsByDay, formatRewardsForGraphs } from './Utils';
 
@@ -47,7 +47,7 @@ export const PayoutLine = (props: PayoutLineProps) => {
   const { isSyncing } = useUi();
   const { inSetup } = useStaking();
   const { membership: poolMembership } = usePoolMemberships();
-  const { payouts, poolClaims } = useSubscan();
+  const { payouts } = useCereStats();
 
   const { units } = network;
   const notStaking = !isSyncing && inSetup() && !poolMembership;
@@ -57,7 +57,7 @@ export const PayoutLine = (props: PayoutLineProps) => {
     days,
     units,
     payouts,
-    poolClaims
+    []
   );
 
   // combine payouts and pool claims into one dataset

--- a/src/library/Graphs/PayoutLine.tsx
+++ b/src/library/Graphs/PayoutLine.tsx
@@ -47,7 +47,7 @@ export const PayoutLine = (props: PayoutLineProps) => {
   const { isSyncing } = useUi();
   const { inSetup } = useStaking();
   const { membership: poolMembership } = usePoolMemberships();
-  const { payouts } = useCereStats();
+  const { payouts, poolClaims } = useCereStats();
 
   const { units } = network;
   const notStaking = !isSyncing && inSetup() && !poolMembership;
@@ -57,7 +57,7 @@ export const PayoutLine = (props: PayoutLineProps) => {
     days,
     units,
     payouts,
-    []
+    poolClaims
   );
 
   // combine payouts and pool claims into one dataset

--- a/src/library/SubscanButton/index.tsx
+++ b/src/library/SubscanButton/index.tsx
@@ -30,11 +30,11 @@ export const SubscanButton = () => {
   return (
     <Wrapper
       color={
-        services.includes('subscan')
+        services.includes('cereStats')
           ? networkColors[`${network.name}-${mode}`]
           : defaultThemes.text.secondary[mode]
       }
-      opacity={services.includes('subscan') ? 1 : 0.5}
+      opacity={services.includes('cereStats') ? 1 : 0.5}
     >
       <FontAwesomeIcon
         icon={faProjectDiagram}

--- a/src/library/SubscanButton/index.tsx
+++ b/src/library/SubscanButton/index.tsx
@@ -41,7 +41,7 @@ export const SubscanButton = () => {
         transform="shrink-2"
         style={{ marginRight: '0.3rem' }}
       />
-      Subscan
+      Cere Stats API
     </Wrapper>
   );
 };

--- a/src/library/SubscanButton/index.tsx
+++ b/src/library/SubscanButton/index.tsx
@@ -41,7 +41,7 @@ export const SubscanButton = () => {
         transform="shrink-2"
         style={{ marginRight: '0.3rem' }}
       />
-      Cere Stats API
+      Cere Stats
     </Wrapper>
   );
 };

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -59,7 +59,7 @@ export const ValidatorMetrics = () => {
             <StatusLabel
               status="active_service"
               statusFor="cereStats"
-              title="CereStats Disabled"
+              title="Cere Stats Disabled"
             />
             <div
               className="graph"

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -58,8 +58,8 @@ export const ValidatorMetrics = () => {
           <div className="inner" ref={ref} style={{ minHeight }}>
             <StatusLabel
               status="active_service"
-              statusFor="subscan"
-              title="Subscan Disabled"
+              statusFor="cereStats"
+              title="CereStats Disabled"
             />
             <div
               className="graph"

--- a/src/modals/ValidatorMetrics/index.tsx
+++ b/src/modals/ValidatorMetrics/index.tsx
@@ -3,7 +3,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { useModal } from 'contexts/Modal';
-import { useSubscan } from 'contexts/Subscan';
+import { useCereStats } from 'contexts/CereStats';
 import { EraPoints as EraPointsGraph } from 'library/Graphs/EraPoints';
 import { SubscanButton } from 'library/SubscanButton';
 import { GraphWrapper } from 'library/Graphs/Wrappers';
@@ -16,7 +16,7 @@ import { StatusLabel } from 'library/StatusLabel';
 export const ValidatorMetrics = () => {
   const { config } = useModal();
   const { address, identity } = config;
-  const { fetchEraPoints }: any = useSubscan();
+  const { fetchEraPoints }: any = useCereStats();
   const { metrics } = useNetworkMetrics();
 
   const [list, setList] = useState([]);

--- a/src/pages/Overview/Payouts.tsx
+++ b/src/pages/Overview/Payouts.tsx
@@ -25,7 +25,7 @@ export const Payouts = () => {
         <StatusLabel
           status="active_service"
           statusFor="cereStats"
-          title="CereStats Disabled"
+          title="Cere Stats Disabled"
           topOffset="37%"
         />
       ) : (

--- a/src/pages/Overview/Payouts.tsx
+++ b/src/pages/Overview/Payouts.tsx
@@ -21,11 +21,11 @@ export const Payouts = () => {
 
   return (
     <div className="inner" ref={ref} style={{ minHeight }}>
-      {!services.includes('subscan') ? (
+      {!services.includes('cereStats') ? (
         <StatusLabel
           status="active_service"
-          statusFor="subscan"
-          title="Subscan Disabled"
+          statusFor="cereStats"
+          title="CereStats Disabled"
           topOffset="37%"
         />
       ) : (

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'Wrappers';
 import { GraphWrapper } from 'library/Graphs/Wrappers';
 import { useApi } from 'contexts/Api';
-import { useSubscan } from 'contexts/Subscan';
+import { useCereStats } from 'contexts/CereStats';
 import { SubscanButton } from 'library/SubscanButton';
 import { PageTitle } from 'library/PageTitle';
 import { formatRewardsForGraphs } from 'library/Graphs/Utils';
@@ -33,9 +33,9 @@ import Returns from './Returns';
 export const Overview = () => {
   const { network } = useApi();
   const { units } = network;
-  const { payouts, poolClaims } = useSubscan();
+  const { payouts } = useCereStats();
 
-  const { lastReward } = formatRewardsForGraphs(14, units, payouts, poolClaims);
+  const { lastReward } = formatRewardsForGraphs(14, units, payouts, []);
 
   const PAYOUTS_HEIGHT = 380;
   const STATS_HEIGHT = 80;

--- a/src/pages/Overview/index.tsx
+++ b/src/pages/Overview/index.tsx
@@ -33,9 +33,9 @@ import Returns from './Returns';
 export const Overview = () => {
   const { network } = useApi();
   const { units } = network;
-  const { payouts } = useCereStats();
+  const { payouts, poolClaims } = useCereStats();
 
-  const { lastReward } = formatRewardsForGraphs(14, units, payouts, []);
+  const { lastReward } = formatRewardsForGraphs(14, units, payouts, poolClaims);
 
   const PAYOUTS_HEIGHT = 380;
   const STATS_HEIGHT = 80;

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -26,8 +26,11 @@ import { BN } from 'bn.js';
 import { PageProps } from '../types';
 import { PayoutList } from './PayoutList';
 import LastEraPayoutStatBox from './Stats/LastEraPayout';
+import { useCereStats } from '../../contexts/CereStats';
 
 export const Payouts = (props: PageProps) => {
+  const cereStats = useCereStats();
+  console.log('cereStats data is', cereStats);
   const { payouts, poolClaims } = useSubscan();
   const { isSyncing, services } = useUi();
   const { inSetup } = useStaking();

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -29,7 +29,7 @@ import LastEraPayoutStatBox from './Stats/LastEraPayout';
 import { useCereStats } from '../../contexts/CereStats';
 
 export const Payouts = (props: PageProps) => {
-  const { payouts } = useCereStats();
+  const { payouts, poolClaims } = useCereStats();
   const { isSyncing, services } = useUi();
   const { inSetup } = useStaking();
   const notStaking = !isSyncing && inSetup();
@@ -43,7 +43,7 @@ export const Payouts = (props: PageProps) => {
 
   // take non-zero rewards in most-recent order
   let payoutsList: AnySubscan = [
-    ...payouts.concat([]).filter((p: AnySubscan) => p.amount > 0),
+    ...payouts.concat(poolClaims).filter((p: AnySubscan) => p.amount > 0),
   ].slice(0, MAX_PAYOUT_DAYS);
 
   // re-order rewards based on block timestamp

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -82,11 +82,11 @@ export const Payouts = (props: PageProps) => {
             </h2>
           </CardHeaderWrapper>
           <div className="inner" ref={ref} style={{ minHeight }}>
-            {!services.includes('subscan') ? (
+            {!services.includes('cereStats') ? (
               <StatusLabel
                 status="active_service"
-                statusFor="subscan"
-                title="Subscan Disabled"
+                statusFor="cereStats"
+                title="CereStats Disabled"
                 topOffset="30%"
               />
             ) : (

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -86,7 +86,7 @@ export const Payouts = (props: PageProps) => {
               <StatusLabel
                 status="active_service"
                 statusFor="cereStats"
-                title="CereStats Disabled"
+                title="Cere Stats Disabled"
                 topOffset="30%"
               />
             ) : (

--- a/src/pages/Payouts/index.tsx
+++ b/src/pages/Payouts/index.tsx
@@ -29,9 +29,7 @@ import LastEraPayoutStatBox from './Stats/LastEraPayout';
 import { useCereStats } from '../../contexts/CereStats';
 
 export const Payouts = (props: PageProps) => {
-  const cereStats = useCereStats();
-  console.log('cereStats data is', cereStats);
-  const { payouts, poolClaims } = useSubscan();
+  const { payouts } = useCereStats();
   const { isSyncing, services } = useUi();
   const { inSetup } = useStaking();
   const notStaking = !isSyncing && inSetup();
@@ -45,7 +43,7 @@ export const Payouts = (props: PageProps) => {
 
   // take non-zero rewards in most-recent order
   let payoutsList: AnySubscan = [
-    ...payouts.concat(poolClaims).filter((p: AnySubscan) => p.amount > 0),
+    ...payouts.concat([]).filter((p: AnySubscan) => p.amount > 0),
   ].slice(0, MAX_PAYOUT_DAYS);
 
   // re-order rewards based on block timestamp

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -39,6 +39,7 @@ export interface Network {
   };
   endpoint: string;
   subscanEndpoint: string;
+  cereStatsEndpoint: string;
   unit: string;
   units: number;
   ss58: number;

--- a/yarn.lock
+++ b/yarn.lock
@@ -19,6 +19,25 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
+"@apollo/client@^3.7.14":
+  version "3.7.14"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.14.tgz#40ef90390e6690e94917457cd82bdeb29e8b6af9"
+  integrity sha512-BRvdkwq5PAXBkjXjboO12uksDm3nrZEqDi4xF97Fk3Mnaa0zDOEfJa7hoKTY9b9KA1EkeWv9BL3i7hSd4SfGBg==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    "@wry/context" "^0.7.0"
+    "@wry/equality" "^0.5.0"
+    "@wry/trie" "^0.3.0"
+    graphql-tag "^2.12.6"
+    hoist-non-react-statics "^3.3.2"
+    optimism "^0.16.2"
+    prop-types "^15.7.2"
+    response-iterator "^0.2.6"
+    symbol-observable "^4.0.0"
+    ts-invariant "^0.10.3"
+    tslib "^2.3.0"
+    zen-observable-ts "^1.2.5"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.18.6", "@babel/code-frame@^7.8.3":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz#3b25d38c89600baa2dcc219edfa88a74eb2c427a"
@@ -1270,6 +1289,11 @@
   integrity sha512-Hyb+lB8T18cvLNX0S3llz7PcSOAJMLwiVKBuuzwM/nI5uoBw+gQjnf9il0fR1C3DKOI5Kc79pkJ4/xB0Uw9aFQ==
   dependencies:
     prop-types "^15.8.1"
+
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
 
 "@humanwhocodes/config-array@^0.9.2":
   version "0.9.5"
@@ -3010,6 +3034,27 @@
     "@webassemblyjs/ast" "1.11.1"
     "@xtuc/long" "4.2.2"
 
+"@wry/context@^0.7.0":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@wry/context/-/context-0.7.3.tgz#240f6dfd4db5ef54f81f6597f6714e58d4f476a1"
+  integrity sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/equality@^0.5.0":
+  version "0.5.6"
+  resolved "https://registry.yarnpkg.com/@wry/equality/-/equality-0.5.6.tgz#cd4a533c72c3752993ab8cbf682d3d20e3cb601e"
+  integrity sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==
+  dependencies:
+    tslib "^2.3.0"
+
+"@wry/trie@^0.3.0":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@wry/trie/-/trie-0.3.2.tgz#a06f235dc184bd26396ba456711f69f8c35097e6"
+  integrity sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==
+  dependencies:
+    tslib "^2.3.0"
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -3504,6 +3549,11 @@ babel-preset-react-app@^10.0.1:
     "@babel/runtime" "^7.16.3"
     babel-plugin-macros "^3.1.0"
     babel-plugin-transform-react-remove-prop-types "^0.4.24"
+
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha512-zj6Z6M7Eq+PBZ7PQxl5NT665MvJdAkzp0f60nAJ+sLaSCBPMwVak5ZegFbgVCzFcCJTKFoMizvM5Ld7+JrRJHA==
 
 balanced-match@^1.0.0:
   version "1.0.2"
@@ -5110,6 +5160,11 @@ ethereum-blockies-base64@^1.0.2:
   dependencies:
     pnglib "0.0.1"
 
+eventemitter3@^3.1.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
+  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
+
 eventemitter3@^4.0.0, eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
@@ -5653,6 +5708,18 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
+graphql-tag@^2.12.6:
+  version "2.12.6"
+  resolved "https://registry.yarnpkg.com/graphql-tag/-/graphql-tag-2.12.6.tgz#d441a569c1d2537ef10ca3d1633b48725329b5f1"
+  integrity sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==
+  dependencies:
+    tslib "^2.1.0"
+
+graphql@^16.6.0:
+  version "16.6.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-16.6.0.tgz#c2dcffa4649db149f6282af726c8c83f1c7c5fdb"
+  integrity sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==
+
 gzip-size@^6.0.0:
   version "6.0.0"
   resolved "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz#065367fd50c239c0671cbcbad5be3e2eeb10e462"
@@ -5728,7 +5795,7 @@ history@^5.2.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6217,6 +6284,11 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterall@^1.2.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jake@^10.8.5:
   version "10.8.5"
@@ -7452,6 +7524,14 @@ open@^8.0.9, open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+optimism@^0.16.2:
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.16.2.tgz#519b0c78b3b30954baed0defe5143de7776bf081"
+  integrity sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==
+  dependencies:
+    "@wry/context" "^0.7.0"
+    "@wry/trie" "^0.3.0"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -8817,6 +8897,11 @@ resolve@^2.0.0-next.3:
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 
+response-iterator@^0.2.6:
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/response-iterator/-/response-iterator-0.2.6.tgz#249005fb14d2e4eeb478a3f735a28fd8b4c9f3da"
+  integrity sha512-pVzEEzrsg23Sh053rmDUvLSkGXluZio0qu8VT6ukrYuvtjVfCbDZH9d6PGXb8HZfzdNZt8feXv/jvUzlhRgLnw==
+
 retry@^0.13.1:
   version "0.13.1"
   resolved "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
@@ -9408,6 +9493,17 @@ stylehacks@^5.1.0:
     browserslist "^4.16.6"
     postcss-selector-parser "^6.0.4"
 
+subscriptions-transport-ws@^0.11.0:
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz#baf88f050cba51d52afe781de5e81b3c31f89883"
+  integrity sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0 || ^6.0.0 || ^7.0.0"
+
 supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -9478,6 +9574,16 @@ svgo@^2.7.0:
     csso "^4.2.0"
     picocolors "^1.0.0"
     stable "^0.1.8"
+
+symbol-observable@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+
+symbol-observable@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-4.0.0.tgz#5b425f192279e87f2f9b937ac8540d1984b39205"
+  integrity sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -9651,6 +9757,13 @@ tryer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
   integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
+ts-invariant@^0.10.3:
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/ts-invariant/-/ts-invariant-0.10.3.tgz#3e048ff96e91459ffca01304dbc7f61c1f642f6c"
+  integrity sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==
+  dependencies:
+    tslib "^2.1.0"
 
 tsconfig-paths@^3.14.1:
   version "3.14.1"
@@ -10347,7 +10460,7 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^7.4.6:
+"ws@^5.2.0 || ^6.0.0 || ^7.0.0", ws@^7.4.6:
   version "7.5.9"
   resolved "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
@@ -10419,3 +10532,15 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zen-observable-ts@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz#6c6d9ea3d3a842812c6e9519209365a122ba8b58"
+  integrity sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==
+  dependencies:
+    zen-observable "0.8.15"
+
+zen-observable@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.15.tgz#96415c512d8e3ffd920afd3889604e30b9eaac15"
+  integrity sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==


### PR DESCRIPTION
# Enable reward history and era points charts by replacing the Subscan API with the Stats App API.

## Added
- Added `CereStatsProvider` feature to fetch data from CereStats API, providing reward history and era points for validators.
- Implemented custom hooks, `useFetchEraPoints` and `usePayouts`, to manage data from CereStats API. `useFetchEraPoints` retrieves era points for a specific validator, while `usePayouts` manages reward history.

## Changed
- The `useSubscan` hook has been replaced with the `useCereStats` hook for the Reward History and Era Point Charts data source.
- Removed dependency on `Subscan API` and simplified data management strategy by using `CereStats` API as primary data source.